### PR TITLE
Adjust autostart location

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ Now select whether you want to set up from the Pi or manage from elsewhere.
 18. `reboot` the pi
 19. Log in to your Google account on the Pi
 20. Put a bow on it. You're done!
+21. The calendar autostarts via `~/.config/lxsession/LXDE-pi/calendar.desktop`.
+    Move that file to `/etc/xdg/autostart` for a system-wide setup.

--- a/roles/calendar/files/autostart
+++ b/roles/calendar/files/autostart
@@ -1,5 +1,0 @@
-@sh /home/pi/startup.sh
-@xset s 0 0
-@xset s noblank
-@xset s noexpose
-@xset dpms 0 0 0

--- a/roles/calendar/tasks/main.yml
+++ b/roles/calendar/tasks/main.yml
@@ -75,17 +75,17 @@
     job: "/home/pi/refresh_cal"
   when: false
 
-- name: Autostart folder 
+- name: LXDE autostart folder
   file:
-    path: "/home/pi/.config/autostart"
+    path: "/home/pi/.config/lxsession/LXDE-pi"
     state: directory
     owner: pi
-    mode: '0755' 
+    mode: '0755'
 
 - name: Autostart the calendar on boot
   copy:
      src: calendar.desktop
-     dest: /home/pi/.config/autostart/calendar.desktop
+     dest: /home/pi/.config/lxsession/LXDE-pi/calendar.desktop
      mode: '0644'
      owner: pi
 


### PR DESCRIPTION
## Summary
- copy `calendar.desktop` to LXDE's autostart folder
- drop unused autostart file
- mention autostart path in the docs

## Testing
- `ansible-playbook playbook.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e8ecad548331a122ce215eea75d6