### PR TITLE
Switch to qutebrowser for lighter calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Calendar Pi
 Did you live your life near the turn of the century by a dry-erase 
 calendar in the kitchen?  Do you long for more visibility into your 
-Google Calendar (or perhaps other online calendar)?  Then look no 
+Google Calendar (or perhaps other online calendar)?  Then look no
 further!  The solution is here.
+
+This setup now uses **qutebrowser** in kiosk mode for a lighter footprint than
+Chromium.
 
 ![Photo of the finished product mounted on a wall near clipboards, dry-erase, and files.](photos/Overview.jpg)
 
@@ -52,3 +55,7 @@ Now select whether you want to set up from the Pi or manage from elsewhere.
 20. Put a bow on it. You're done!
 21. The calendar autostarts via `~/.config/lxsession/LXDE-pi/calendar.desktop`.
     Move that file to `/etc/xdg/autostart` for a system-wide setup.
+
+## Testing
+Run `make package` to build the installation archive. This step exercises the
+packaging scripts and ensures everything is wired correctly.

--- a/roles/calendar/files/restart.sh
+++ b/roles/calendar/files/restart.sh
@@ -16,11 +16,11 @@ if [ ! -z "$OLD_CAL_WINDOW" ] ; then
    wmctrl -ic "$OLD_CAL_WINDOW"
 fi
 sleep 1
-# Try to stop any running Chromium browser, regardless of the exact binary name
-pkill -f chromium-browser || :
+# Try to stop any running qutebrowser instance
+pkill -f qutebrowser || :
 sleep 2
-# Force kill any lingering Chromium processes
-pkill -9 -f chromium-browser 2>&1 >/dev/null || :
+# Force kill any lingering qutebrowser processes
+pkill -9 -f qutebrowser 2>&1 >/dev/null || :
 
 # Restart the calendar window
 ./startup.sh

--- a/roles/calendar/files/startup.sh
+++ b/roles/calendar/files/startup.sh
@@ -3,5 +3,5 @@
 # If booting without keyboard/mouse/ethernet, turn off USB power
 # [ $(lsusb | wc -l) -lt 4 ] && echo '1-1' | sudo tee /sys/bus/usb/drivers/usb/unbind
 
-# Start the browser
-chromium-browser --app=https://calendar.google.com/calendar/r/custom/7/d --user-agent="Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201" --disable-infobars --disable-session-crashed-bubble --kiosk &
+# Start the browser using qutebrowser in fullscreen mode
+qutebrowser ':open https://calendar.google.com/calendar/r/custom/7/d' ':fullscreen' &

--- a/roles/calendar/tasks/main.yml
+++ b/roles/calendar/tasks/main.yml
@@ -1,6 +1,6 @@
-- name: Install Chromium
-  package: 
-      name: chromium-browser
+- name: Install qutebrowser
+  package:
+      name: qutebrowser
       state: latest
 
 - name: Install scrot


### PR DESCRIPTION
## Summary
- use qutebrowser instead of chromium
- start/stop qutebrowser in scripts
- document browser choice and how to run packaging tests

## Testing
- `make package`


------
https://chatgpt.com/codex/tasks/task_e_6868539bd68c8331867dd2f2802e7c68