### PR TITLE
Fix release README link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Update version files
         run: |
           echo "${{ steps.vars.outputs.version }}" > release_number.txt
-          sed -i "s/calendar-install-[0-9]\+.run/calendar-install-${{ steps.vars.outputs.version }}.run/" README.md
+          sed -i "s#releases/download/[a-zA-Z0-9._-]*/calendar-install-[0-9]\+.run#releases/download/${{ github.event.release.tag_name }}/calendar-install-${{ steps.vars.outputs.version }}.run#" README.md
           git add release_number.txt README.md
           git commit -m "Release version ${{ steps.vars.outputs.version }}"
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ use the default user "pi" to run the calendar, and this user has sudo permission
 Now select whether you want to set up from the Pi or manage from elsewhere.
 
 ## Setting up just from the Pi
-8. `curl -L https://github.com/ke4roh/rpi-calendar/releases/download/r1/calendar-install-5.run | bash`
+8. `curl -L https://github.com/ke4roh/rpi-calendar/releases/download/v5/calendar-install-5.run | bash`
 
 ## Setting up from a remote system
 11. Enable SSH on the Pi either in system preferences or by placing an empty file named `ssh` on the boot partition before first boot.


### PR DESCRIPTION
## Summary
- correct installation link in README
- update GitHub Actions workflow to update README link with tag

## Testing
- `make package`

------
https://chatgpt.com/codex/tasks/task_e_68686a8e32b88331bb5374ef5e9d29c7