### PR TITLE
Restore Chromium for full calendar features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ calendar in the kitchen?  Do you long for more visibility into your
 Google Calendar (or perhaps other online calendar)?  Then look no
 further!  The solution is here.
 
-This setup now uses **qutebrowser** in kiosk mode for a lighter footprint than
-Chromium.
+This setup runs **Chromium** in kiosk mode. A modern user agent string keeps
+Google Calendar happy while providing full ECMAScript and CSS support.
 
 ![Photo of the finished product mounted on a wall near clipboards, dry-erase, and files.](photos/Overview.jpg)
 

--- a/roles/calendar/files/restart.sh
+++ b/roles/calendar/files/restart.sh
@@ -16,11 +16,11 @@ if [ ! -z "$OLD_CAL_WINDOW" ] ; then
    wmctrl -ic "$OLD_CAL_WINDOW"
 fi
 sleep 1
-# Try to stop any running qutebrowser instance
-pkill -f qutebrowser || :
+# Try to stop any running Chromium browser, regardless of the exact binary name
+pkill -f chromium-browser || :
 sleep 2
-# Force kill any lingering qutebrowser processes
-pkill -9 -f qutebrowser 2>&1 >/dev/null || :
+# Force kill any lingering Chromium processes
+pkill -9 -f chromium-browser 2>&1 >/dev/null || :
 
 # Restart the calendar window
 ./startup.sh

--- a/roles/calendar/files/startup.sh
+++ b/roles/calendar/files/startup.sh
@@ -3,5 +3,7 @@
 # If booting without keyboard/mouse/ethernet, turn off USB power
 # [ $(lsusb | wc -l) -lt 4 ] && echo '1-1' | sudo tee /sys/bus/usb/drivers/usb/unbind
 
-# Start the browser using qutebrowser in fullscreen mode
-qutebrowser ':open https://calendar.google.com/calendar/r/custom/7/d' ':fullscreen' &
+# Start the browser using Chromium with an updated user agent
+chromium-browser --app=https://calendar.google.com/calendar/r/custom/7/d \
+  --user-agent="Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36" \
+  --disable-infobars --disable-session-crashed-bubble --kiosk &

--- a/roles/calendar/tasks/main.yml
+++ b/roles/calendar/tasks/main.yml
@@ -1,6 +1,6 @@
-- name: Install qutebrowser
+- name: Install Chromium
   package:
-      name: qutebrowser
+      name: chromium-browser
       state: latest
 
 - name: Install scrot


### PR DESCRIPTION
## Summary
- document Chromium as the kiosk browser again
- install Chromium via Ansible instead of qutebrowser
- launch Chromium with a modern user agent
- ensure restart script kills Chromium

## Testing
- `make package`

------
https://chatgpt.com/codex/tasks/task_e_686881a49b2883319f764fcf8d533017