### PR TITLE
Add Wayland option to Ansible setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Now select whether you want to set up from the Pi or manage from elsewhere.
 12. On the configuring machine, install Ansible (for Debian/Ubuntu: `sudo apt-get install ansible`) and clone this repo.
 13. Run `ssh-copy-id pi@<pi-hostname>` to set up key-based access.
 14. Copy `hosts-localhost` to a new file named `hosts` and replace `localhost` with the Pi's hostname or IP.
-15. `ansible-playbook playbook.yml -i hosts -u pi`
+15. If you want to try the new Wayland-based desktop, set `use_wayland: true` in
+    your inventory or pass it via `--extra-vars`.
+16. `ansible-playbook playbook.yml -i hosts -u pi`
 
 ## Finishing up
 18. `reboot` the pi

--- a/roles/calendar/defaults/main.yml
+++ b/roles/calendar/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default to using X11
+use_wayland: false

--- a/roles/calendar/tasks/main.yml
+++ b/roles/calendar/tasks/main.yml
@@ -18,9 +18,15 @@
       name: wmctrl
       state: latest
 
-- name: Detect desktop session type
+- name: Determine desired session type
   set_fact:
-     session_type: "{{ ansible_env.XDG_SESSION_TYPE | default('x11') }}"
+     session_type: "{{ 'wayland' if use_wayland else 'x11' }}"
+
+- name: Configure Wayland preference
+  command: "raspi-config nonint do_wayland {{ 0 if use_wayland else 1 }}"
+  register: wayland_config_result
+  changed_when: wayland_config_result.rc == 0
+  failed_when: wayland_config_result.rc not in [0,1]
 
 - name: Install unclutter to get the mouse pointer to disappear
   package:


### PR DESCRIPTION
## Summary
- allow enabling Wayland desktop through a new `use_wayland` variable
- automatically configure the Raspberry Pi with `raspi-config`
- document Wayland option in setup instructions

## Testing
- `make package`


------
https://chatgpt.com/codex/tasks/task_e_686885784bd08331832a89b78be20db5