### PR TITLE
Rename DPMS timeout var

### DIFF
--- a/roles/calendar/vars/main.yml
+++ b/roles/calendar/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 # Screensaver timeout in minutes - 0 means no timeout
 # Configure a PIR sensor to show the display when necessary
-DPMS_TIMEOUT: 0
+DPMS_TIMEOUT_MIN: 0


### PR DESCRIPTION
## Summary
- rename `DPMS_TIMEOUT` to `DPMS_TIMEOUT_MIN`

## Testing
- `ansible-playbook playbook.yml --syntax-check -i hosts-localhost`

------
https://chatgpt.com/codex/tasks/task_e_68697d0fe544833181fd1a76b89c1504