### PR TITLE
Fix EXTRA_VARS check in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ grep -q localhost $kh || ssh-keyscan localhost >>$kh
 # install Ansible if necessary
 sudo dpkg -s ansible 2>&1 >/dev/null || sudo apt-get install -y ansible
 
-if [ !# -gt 0 ] ; then
-    EXTRA_VARS="--extra_vars $*"
+if [ $# -gt 0 ]; then
+    EXTRA_VARS="--extra-vars $*"
 fi
 ansible-playbook playbook.yml -i hosts-localhost -u pi $EXTRA_VARS


### PR DESCRIPTION
## Summary
- fix the argument check in install.sh
- use --extra-vars flag for ansible
- validate script syntax

## Testing
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68697ddb2d6883319b2423825e826f18