### PR TITLE
Improve PIR sensor monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,5 @@ If you change the scripts, you can change the pin.
 6. Mount the HC-SR501 to your monitor, but away from the power LED or anything else that might mess with detection.
 7. When you run the playbook (either by `ansible-playbook` or `calendar-install.run`), add a parameter 'DPMS_TIMEOUT_MIN=20'.
 (Set it to your favorite value.  I like 20 minutes.)  For `ansible-playbook` execution, you'll want to prefix that with `--extra-vars `
-8. Watch it go 
+8. The playbook installs a `pir-monitor` systemd service that wakes the display when motion is detected. Set `CEC_FALLBACK=true` if your monitor needs HDMI‑CEC to wake up. The service starts automatically on boot and can be checked with `systemctl status pir-monitor`.
+9. Watch it go

--- a/roles/calendar/files/pir-monitor.service.j2
+++ b/roles/calendar/files/pir-monitor.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=PIR sensor monitor to wake display on motion
+After=graphical.target
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+ExecStart=/usr/local/bin/pirMonitor
+Environment=DISPLAY=:0.0
+Environment=CEC_FALLBACK={{ '1' if CEC_FALLBACK | bool else '0' }}
+Restart=always
+
+[Install]
+WantedBy=graphical.target

--- a/roles/calendar/files/pirMonitor
+++ b/roles/calendar/files/pirMonitor
@@ -1,28 +1,93 @@
 #!/usr/bin/env python3
 
-# Started from https://www.freva.com/2019/05/21/hc-sr501-pir-motion-sensor-on-raspberry-pi/
+"""Monitor a PIR sensor and wake the display when motion is detected."""
+
+import argparse
+import logging
+import os
+import shutil
+import subprocess
+import time
 
 import RPi.GPIO as GPIO
-import time
-import subprocess
-import os
 
-os.environ['DISPLAY'] = ":0.0"
-max_idle=30
 
-try:
-   GPIO.setmode(GPIO.BCM)
-   GPIO.setwarnings(False)
-   PIR_PIN = 23
-   GPIO.setup(PIR_PIN, GPIO.IN)
+def display_is_on() -> bool:
+    """Return True if the monitor appears to be on."""
+    try:
+        out = subprocess.check_output(["xset", "-q"], text=True, stderr=subprocess.DEVNULL)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return True  # Assume on if we cannot determine
+    for line in out.splitlines():
+        if "Monitor is" in line:
+            return "On" in line
+    return True
 
-   time.sleep(1)
 
-   next_check=0
-   while True:
-     if time.time() >= next_check and GPIO.input(PIR_PIN):
-       subprocess.call('xset dpms force on', shell=True)
-       next_check=time.time() + max_idle
-     time.sleep(1)
-finally:
-   GPIO.cleanup()
+def wake_display(use_cec: bool) -> None:
+    """Wake the display using DPMS and optionally HDMI-CEC."""
+    if os.getenv("XDG_SESSION_TYPE") == "wayland":
+        cmd = ["loginctl", "unlock-sessions"]
+    else:
+        cmd = ["xset", "dpms", "force", "on"]
+    subprocess.run(cmd, check=False)
+    time.sleep(2)
+    if use_cec and not display_is_on():
+        logging.info("Falling back to HDMI-CEC")
+        if shutil.which("cec-client"):
+            try:
+                subprocess.run(
+                    ["cec-client", "-s", "-d", "1"],
+                    input="on 0\n",
+                    text=True,
+                    check=False,
+                )
+            except Exception as exc:  # pragma: no cover - best effort
+                logging.debug("CEC command failed: %s", exc)
+        else:
+            logging.debug("cec-client not installed")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="PIR motion monitor")
+    parser.add_argument("--pin", type=int, default=23, help="GPIO pin number")
+    parser.add_argument(
+        "--idle",
+        type=int,
+        default=30,
+        help="minimum seconds between wake commands",
+    )
+    parser.add_argument("--display", default=":0.0", help="display for xset")
+    parser.add_argument(
+        "--cec-fallback",
+        action="store_true",
+        default=os.getenv("CEC_FALLBACK", "0") in ("1", "true", "True"),
+        help="use HDMI-CEC if DPMS fails",
+    )
+    args = parser.parse_args()
+
+    os.environ["DISPLAY"] = args.display
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setwarnings(False)
+    GPIO.setup(args.pin, GPIO.IN)
+
+    last_trigger = 0.0
+    logging.info("Monitoring GPIO pin %s", args.pin)
+    try:
+        while True:
+            GPIO.wait_for_edge(args.pin, GPIO.RISING)
+            now = time.time()
+            if now - last_trigger >= args.idle:
+                logging.info("Motion detected")
+                wake_display(args.cec_fallback)
+                last_trigger = now
+    except KeyboardInterrupt:
+        pass
+    finally:
+        GPIO.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/calendar/files/startup.sh
+++ b/roles/calendar/files/startup.sh
@@ -6,5 +6,4 @@
 # Start the browser
 nohup chromium-browser --app=https://calendar.google.com/calendar/r/custom/7/d --user-agent="Mozilla/5.0 (Windows; U; Windows NT 6.1; rv:2.2) Gecko/20110201" --disable-infobars --disable-session-crashed-bubble --kiosk </dev/null 2>&1 >/dev/null  &
 
-# If blanking is requested, then run pirMonitor to make motion keep it from blanking
-grep -q noblank /etc/xdg/lxsession/LXDE-pi/autostart || nohup /home/pi/pirMonitor </dev/null 2>&1 >/dev/null &
+# The pir-monitor systemd service handles keeping the display awake when blanking is enabled

--- a/roles/calendar/tasks/main.yml
+++ b/roles/calendar/tasks/main.yml
@@ -32,6 +32,12 @@
       name: unclutter
       state: latest
 
+- name: Install cec-utils for HDMI-CEC control
+  package:
+      name: cec-utils
+      state: latest
+  when: CEC_FALLBACK | bool
+
 - name: Install python-uinput to fake keystrokes in the browser
   pip: 
      executable: /usr/bin/pip3
@@ -116,10 +122,25 @@
 - name: Copy the script to monitor PIR sensor
   copy:
      src: pirMonitor
-     dest: /home/pi/pirMonitor
-     mode: '755'
-     owner: pi
-     group: pi
+     dest: /usr/local/bin/pirMonitor
+     mode: '0755'
+     owner: root
+     group: root
+  when: ( DPMS_TIMEOUT_MIN | int ) > 0
+
+- name: Install systemd service for PIR monitor
+  template:
+     src: pir-monitor.service.j2
+     dest: /etc/systemd/system/pir-monitor.service
+     mode: '0644'
+  when: ( DPMS_TIMEOUT_MIN | int ) > 0
+
+- name: Enable and start pir-monitor service
+  systemd:
+     name: pir-monitor.service
+     enabled: yes
+     state: started
+     daemon_reload: yes
   when: ( DPMS_TIMEOUT_MIN | int ) > 0
 
 - name: Turn on screensaver in LXDE autostart

--- a/roles/calendar/vars/main.yml
+++ b/roles/calendar/vars/main.yml
@@ -2,3 +2,5 @@
 # Screensaver timeout in minutes - 0 means no timeout
 # Configure a PIR sensor to show the display when necessary
 DPMS_TIMEOUT_MIN: 0
+# Enable HDMI-CEC fallback if DPMS does not wake the display
+CEC_FALLBACK: false


### PR DESCRIPTION
## Summary
- refactor pirMonitor script to use event-driven GPIO
- add a systemd service for the monitor
- install the service and script with Ansible
- clean up startup script
- document service usage in README
- add HDMI-CEC fallback to wake display when DPMS fails

## Testing
- `ansible-playbook playbook.yml --syntax-check`
- `python3 -m py_compile roles/calendar/files/pirMonitor`


------
https://chatgpt.com/codex/tasks/task_e_688661483da083318d8fe6942d1a00cb